### PR TITLE
Feature/breaking change ignore keys instead of line number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,23 @@
-## [0.4.0]
+## [0.5.0] - XX/XX/2021
+
+* Added ability to completely ignore certain keys during text replacement. This is a breaking change as previously line numbers were used.
+
+## [0.4.0] - 07/04/2021
 
 * Aligns analysis options to pedantic used by Google instead of custom Effective Dart options.
 * Null safety migration.
 
-## [0.3.0]
+## [0.3.0] - 28/07/2020
 
 * Added ability to completely ignore certain lines during text replacement.
 * Removed dependency on Flutter, thus Dart-only projects can now avail of this package.
 * Improved code coverage.
 
-## [0.2.0]
+## [0.2.0] - 04/02/2020
 
 * Added Setting to ignore certain expressions during text replacement, i.e. product name or regexp for variables.
 
-## [0.1.0]
+## [0.1.0] - 10/12/2019
 
 * Initial beta version.
 * Generates pseudolocalizations with a selection of extended Latin characters for given localization strings.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ flutter pub run flutter_pseudolocalizor
 
 to generate `test-PSEUDO.csv`. This generated file can then be incorporated into your dev build using a package like [flappy_translator](https://pub.dev/packages/flappy_translator).
 
-Note that `patterns_to_ignore` is especially useful to avoid text replacement for certain know constructs, for instance a product name or a pattern ``%myVar$d` used to parse variables from text.
+Note that `patterns_to_ignore` is especially useful to avoid text replacement for certain know constructs, for instance a product name or a pattern `%myVar$d` used to parse variables from text.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ flutter_pseudolocalizor:
 | csv_settings: delimiter    | A delimiter to separate columns in the input CSV file. Defaults to `,`.                  |
 | csv_settings: column_index | The column index of the base language (en) in the input CSV file. Defaults to `1`.       |
 | patterns_to_ignore         | A list of patterns to ignore during text replacement.                                    |
-| line_numbers_to_ignore     | A list of line numbers which should be ignored.                                          |
+| keys_to_ignore             | A list of keys which should be ignored.                                                  |
 
 `input_filepath` must be given, all other settings are optional. If Latin-1 Supplement and Latin Extended-A letters should be tested, set `replace_base` to true. To test specific languages, set `languages_to_generate` with an array of languages.
 
@@ -104,7 +104,7 @@ flutter pub run flutter_pseudolocalizor
 
 to generate `test-PSEUDO.csv`. This generated file can then be incorporated into your dev build using a package like [flappy_translator](https://pub.dev/packages/flappy_translator).
 
-Note that `patterns_to_ignore` is especially useful to avoid text replacement for certain know constructs, for instance a product name or a pattern ``%myVar$d` used to parse variables from text. `line_numbers_to_ignore` is the actual line number as seen in a text document.
+Note that `patterns_to_ignore` is especially useful to avoid text replacement for certain know constructs, for instance a product name or a pattern ``%myVar$d` used to parse variables from text.
 
 ## Limitations
 
@@ -114,7 +114,6 @@ Note that `patterns_to_ignore` is especially useful to avoid text replacement fo
 - Only text expansion is considered.
 - Only one character replacement style.
 - Except for Spanish, punctuation isn't considered for text expansion.
-- No ability to ignore certain text constructs (i.e. `%myVar$d`) when replacing characters.
 
 ## Future Plans
 

--- a/bin/utils/yaml_parser.dart
+++ b/bin/utils/yaml_parser.dart
@@ -14,7 +14,7 @@ class YamlArguments {
   static const textExpansionRatio = 'text_expansion_ratio';
   static const csvSettings = 'csv_settings';
   static const patternsToIgnore = 'patterns_to_ignore';
-  static const lineNumbersToIgnore = 'line_numbers_to_ignore';
+  static const keysToIgnore = 'keys_to_ignore';
 }
 
 /// A class of arguments which the user can specify in pubspec.yaml for csv_settings object
@@ -58,8 +58,8 @@ class YamlParser {
         csvSettings: csvSettings,
         patternsToIgnore:
             _yamlListToStringList(yamlMap[YamlArguments.patternsToIgnore]),
-        lineNumbersToIgnore:
-            _yamlListToIntList(yamlMap[YamlArguments.lineNumbersToIgnore]),
+        keysToIgnore:
+            _yamlListToStringList(yamlMap[YamlArguments.keysToIgnore]),
       );
     }
 
@@ -92,10 +92,6 @@ class YamlParser {
       inputList != null
           ? inputList.map((item) => item.toString()).toList()
           : null;
-
-  /// Converts a YamlList? into a List<int>?
-  static List<int>? _yamlListToIntList<T>(YamlList? inputList) =>
-      inputList != null ? inputList.map<int>((item) => item).toList() : null;
 
   /// Converts a dynamic to a double?
   static double? _dynamicToDouble(dynamic input) {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -31,5 +31,5 @@ flutter_pseudolocalizor:
   patterns_to_ignore:
     - '%(\S*?)\$[ds]'
     - 'Flutter'
-  line_numbers_to_ignore:
-    - 2
+  keys_to_ignore:
+    - 'title'

--- a/lib/src/models/package_settings.dart
+++ b/lib/src/models/package_settings.dart
@@ -30,8 +30,8 @@ class PackageSettings {
   /// A RegExp to ignore during text replacement.
   final RegExp? patternToIgnore;
 
-  /// A list of line numbers which should be ignored.
-  final List<int>? lineNumbersToIgnore;
+  /// A list of keys which should be ignored.
+  final List<String>? keysToIgnore;
 
   /// Constructs a new instance of [PackageSettings]
   PackageSettings({
@@ -42,7 +42,7 @@ class PackageSettings {
     required bool? useBrackets,
     required this.textExpansionRatio,
     required List<String>? patternsToIgnore,
-    required this.lineNumbersToIgnore,
+    required this.keysToIgnore,
     CSVSettings? csvSettings,
   })  : outputFilepath = outputFilepath ??
             Utils.generateOutputFilePath(inputFilepath: inputFilepath)!,
@@ -56,5 +56,5 @@ class PackageSettings {
   /// Returns a String representation of the model.
   @override
   String toString() =>
-      '{inputFilepath: $inputFilepath, outputFilepath: $outputFilepath, replaceBase: $replaceBase, languagesToGenerate: $languagesToGenerate, useBrackets: $useBrackets, textExpansionRatio: $textExpansionRatio, patternToIgnore: $patternToIgnore, lineNumbersToIgnore: $lineNumbersToIgnore}';
+      '{inputFilepath: $inputFilepath, outputFilepath: $outputFilepath, replaceBase: $replaceBase, languagesToGenerate: $languagesToGenerate, useBrackets: $useBrackets, textExpansionRatio: $textExpansionRatio, patternToIgnore: $patternToIgnore, keysToIgnore: $keysToIgnore}';
 }

--- a/lib/src/services/csv_generator.dart
+++ b/lib/src/services/csv_generator.dart
@@ -41,11 +41,15 @@ class CSVGenerator with PseudoGenerator {
           packageSettings.csvSettings.columnIndex]);
     }
 
+    final locaKeys = lines
+        .map((line) => line.split(packageSettings.csvSettings.delimiter).first)
+        .toList();
+
     final outputLines = List<String>.from(lines);
     if (packageSettings.replaceBase) {
       for (var i = 1; i < outputLines.length; i++) {
         final shouldReplace =
-            packageSettings.lineNumbersToIgnore?.contains(i + 1) ?? true;
+            !(packageSettings.keysToIgnore?.contains(locaKeys[i]) ?? false);
         if (shouldReplace) {
           final pseudoText = PseudoGenerator.generatePseudoTranslation(
             locaBase[i - 1],
@@ -67,7 +71,7 @@ class CSVGenerator with PseudoGenerator {
         final baseText = locaBase[i];
         final generated = <String>[];
         final shouldReplace =
-            packageSettings.lineNumbersToIgnore?.contains(i + 2) ?? true;
+            !(packageSettings.keysToIgnore?.contains(locaKeys[i + 1]) ?? false);
 
         for (final languageToGenerate in packageSettings.languagesToGenerate!) {
           final pseudoTranslation = shouldReplace

--- a/test/models/package_settings_test.dart
+++ b/test/models/package_settings_test.dart
@@ -12,7 +12,7 @@ void main() {
       textExpansionRatio: null,
       csvSettings: null,
       patternsToIgnore: null,
-      lineNumbersToIgnore: null,
+      keysToIgnore: null,
     );
 
     expect(packageSettings, isNotNull);
@@ -24,7 +24,7 @@ void main() {
     expect(packageSettings.textExpansionRatio, isNull);
     expect(packageSettings.csvSettings, isNotNull);
     expect(packageSettings.patternToIgnore, isNull);
-    expect(packageSettings.lineNumbersToIgnore, isNull);
+    expect(packageSettings.keysToIgnore, isNull);
   });
 
   test('When languagesToGenerate constructor param non-null, expect given', () {
@@ -37,7 +37,7 @@ void main() {
       textExpansionRatio: null,
       csvSettings: null,
       patternsToIgnore: null,
-      lineNumbersToIgnore: null,
+      keysToIgnore: null,
     );
 
     expect(packageSettings.inputFilepath, isNotNull);
@@ -48,7 +48,7 @@ void main() {
     expect(packageSettings.textExpansionRatio, isNull);
     expect(packageSettings.csvSettings, isNotNull);
     expect(packageSettings.patternToIgnore, isNull);
-    expect(packageSettings.lineNumbersToIgnore, isNull);
+    expect(packageSettings.keysToIgnore, isNull);
   });
 
   test('Expect toString is overridden', () {
@@ -61,7 +61,7 @@ void main() {
       textExpansionRatio: null,
       csvSettings: null,
       patternsToIgnore: null,
-      lineNumbersToIgnore: null,
+      keysToIgnore: null,
     );
 
     expect(packageSettings.toString(), isNot("Instance of 'PackageSettings'"));

--- a/test/services/csv_generator_test.dart
+++ b/test/services/csv_generator_test.dart
@@ -30,7 +30,7 @@ subtitle;A subtitle
       textExpansionRatio: null,
       csvSettings: csvSettings,
       patternsToIgnore: null,
-      lineNumbersToIgnore: null,
+      keysToIgnore: null,
     );
 
     final contents = CSVGenerator.generate(file, packageSettings)!;
@@ -63,7 +63,7 @@ subtitle;A subtitle
       textExpansionRatio: null,
       csvSettings: csvSettings,
       patternsToIgnore: null,
-      lineNumbersToIgnore: null,
+      keysToIgnore: null,
     );
 
     final contents = CSVGenerator.generate(file, packageSettings)!;


### PR DESCRIPTION
To better support other file types, this PR adds the ability to completely ignore certain keys during text replacement. This is a breaking change as previously line numbers were used.