### PR TITLE
Bugfix/repeat vowels base text contains no vowels

### DIFF
--- a/lib/src/extensions/string_extensions.dart
+++ b/lib/src/extensions/string_extensions.dart
@@ -11,4 +11,15 @@ extension StringExtensions on String {
 
     return _vowels.contains(toLowerCase());
   }
+
+  /// Determines if a String contains at least one vowel
+  bool get hasVowels {
+    for (final char in split('')) {
+      if (char.isVowel) {
+        return true;
+      }
+    }
+
+    return false;
+  }
 }

--- a/lib/src/services/pseudo_generator.dart
+++ b/lib/src/services/pseudo_generator.dart
@@ -37,21 +37,28 @@ mixin PseudoGenerator {
           );
           break;
         case TextExpansionFormat.repeatVowels:
-          var count = 0;
-          while (count < numberOfExpansionCharactersToGenerate) {
-            _baseText = patternToIgnore != null
-                ? _baseText.splitMapJoin(
-                    patternToIgnore,
-                    onNonMatch: (value) => repeatVowels(value,
-                        count: (numberOfExpansionCharactersToGenerate *
-                                (value.length / baseText.length))
-                            .floor()),
-                  )
-                : repeatVowels(
-                    _baseText,
-                    count: numberOfExpansionCharactersToGenerate - count,
-                  );
-            count = _baseText.length - baseText.length;
+          if (baseText.hasVowels) {
+            var count = 0;
+            while (count < numberOfExpansionCharactersToGenerate) {
+              _baseText = patternToIgnore != null
+                  ? _baseText.splitMapJoin(
+                      patternToIgnore,
+                      onNonMatch: (value) => repeatVowels(value,
+                          count: (numberOfExpansionCharactersToGenerate *
+                                  (value.length / baseText.length))
+                              .floor()),
+                    )
+                  : repeatVowels(
+                      _baseText,
+                      count: numberOfExpansionCharactersToGenerate - count,
+                    );
+              count = _baseText.length - baseText.length;
+            }
+          } else {
+            textExpansion = generateRandomSpecialCharacters(
+              numberOfExpansionCharactersToGenerate,
+              language: languageToGenerate,
+            );
           }
           break;
         case TextExpansionFormat.numberWords:

--- a/test/extensions/string_extensions_test.dart
+++ b/test/extensions/string_extensions_test.dart
@@ -56,5 +56,17 @@ void main() {
         );
       });
     });
+
+    group('hasVowels', () {
+      test('Text contains at least one vowel, expect true', () {
+        expect('Vowel'.hasVowels, isTrue);
+        expect('a'.hasVowels, isTrue);
+      });
+
+      test('Text contains no vowels, expect false', () {
+        expect('N Vwl'.hasVowels, isFalse);
+        expect('b'.hasVowels, isFalse);
+      });
+    });
   });
 }


### PR DESCRIPTION
Fixes an edge case where if TextExpansionFormat.repeatVowels was selected and baseText contained no vowels, an infinite loop would occur. Solution is to instead use TextExpansionFormat.append in such cases.