### PR TITLE
Bugfix/crash when copying base output dir does not exist

### DIFF
--- a/lib/src/services/pseudolocalizor.dart
+++ b/lib/src/services/pseudolocalizor.dart
@@ -56,7 +56,7 @@ class Pseudolocalizor {
         final fileContents = ARBGenerator.generate(file, packageSettings);
         outputFile.createRecursivelyAndWriteContents(fileContents);
       } else {
-        file.copySync(outputFile.path);
+        outputFile.createRecursivelyAndWriteContents(file.readAsStringSync());
         print('Wrote to ${outputFile.path}');
       }
 


### PR DESCRIPTION
Fixes a bug where in the case of not replacing base when generating languages, copying base would fail if the target directory did not exist. An uncaught exception was thrown and process crashed.